### PR TITLE
Correct wrong variable name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ PHP    compiled with module API=20220829
 These options need to match
 ```
 
-You can change the version by setting the `DDTRACE_EXT_VERSION` config var in Heroku. For example:
+You can change the version by setting the `DDTRACE_EXT_RELEASE` config var in Heroku. For example:
 
 ```
-heroku config:set --app <your-app-name> DDTRACE_EXT_VERSION=20220829
+heroku config:set --app <your-app-name> DDTRACE_EXT_RELEASE=20220829
 ```

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ PHP    compiled with module API=20220829
 These options need to match
 ```
 
-You can change the version by setting the `DDTRACE_EXT_RELEASE` config var in Heroku. For example:
+You can change the version by setting the `DDTRACE_EXT_PHP_API` config var in Heroku. For example:
 
 ```
-heroku config:set --app <your-app-name> DDTRACE_EXT_RELEASE=20220829
+heroku config:set --app <your-app-name> DDTRACE_EXT_PHP_API=20220829
 ```


### PR DESCRIPTION
In the readme it gives an example to update `DDTRACE_EXT_VERSION` but the variable is actually called `DDTRACE_EXT_PHP_API`.