### PR TITLE
Use `dd-library-php` files and utilise cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This buildpack accepts several config vars. All of them are optional:
 
 - `DDTRACE_EXT_PHP_API` - The PHP API version that your application uses. Defaults to `20210902`. Use `phpinfo()` to find the API version if you're not sure.
 - `DDTRACE_EXT_RELEASE` - The release name of [dd-trace-php](https://github.com/DataDog/dd-trace-php/releases/) to download. Defaults to `0.82.0`.
-- `DDTRACE_EXT_PKG_URL` - The URL to a dd-trace-php `.deb` file. This option overides `DDTRACE_EXT_RELEASE`.
+- `DDTRACE_EXT_PKG_URL` - The URL to a dd-trace-php `.tar.gz` file. This option overides `DDTRACE_EXT_RELEASE`.
 - `DD_PROFILING_ENABLED` - This will enable the profiling extension.
 
 ### More information: `DDTRACE_EXT_PHP_API`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This buildpack accepts several config vars. All of them are optional:
 - `DDTRACE_EXT_PHP_API` - The PHP API version that your application uses. Defaults to `20210902`. Use `phpinfo()` to find the API version if you're not sure.
 - `DDTRACE_EXT_RELEASE` - The release name of [dd-trace-php](https://github.com/DataDog/dd-trace-php/releases/) to download. Defaults to `0.82.0`.
 - `DDTRACE_EXT_PKG_URL` - The URL to a dd-trace-php `.deb` file. This option overides `DDTRACE_EXT_RELEASE`.
+- `DD_PROFILING_ENABLED` - This will enable the profiling extension.
 
 ### More information: `DDTRACE_EXT_PHP_API`
 

--- a/bin/compile
+++ b/bin/compile
@@ -87,7 +87,6 @@ else
 fi
 
 INI_FILE=/app/.heroku/php/etc/php/conf.d/datadog-php-custom.ini
-INI_FILE=datadog-php-custom.ini
 
 touch $INI_FILE
 echo "[PHP]" >> $INI_FILE

--- a/bin/compile
+++ b/bin/compile
@@ -39,7 +39,7 @@ export_env_dir() {
 
 export_env_dir "$ENV_DIR" '^DDTRACE_EXT_'
 
-topic "Preparing to install ddtrace PHP extension"
+topic "Preparing to install Datadog PHP extensions"
 
 if [[ -n ${DDTRACE_EXT_PKG_URL:-} ]]; then
     echo "Using package URL '$DDTRACE_EXT_PKG_URL' (from "'$DDTRACE_EXT_PKG_URL env var).' | indent
@@ -47,27 +47,37 @@ else
     if [[ -n ${DDTRACE_EXT_RELEASE:-} ]]; then
         echo "Using dd-trace-php release '$DDTRACE_EXT_RELEASE' (from "'$DDTRACE_EXT_RELEASE env var).' | indent
     else
-        export DDTRACE_EXT_RELEASE="0.82.0"
+        export DDTRACE_EXT_RELEASE="0.87.2"
         echo "Using dd-trace-php release '$DDTRACE_EXT_RELEASE' (default value)." | indent
     fi
-    export DDTRACE_EXT_PKG_URL="https://github.com/DataDog/dd-trace-php/releases/download/"$DDTRACE_EXT_RELEASE"/datadog-php-tracer_"$DDTRACE_EXT_RELEASE"_amd64.deb"
+    export DDTRACE_EXT_PKG_URL="https://github.com/DataDog/dd-trace-php/releases/download/"$DDTRACE_EXT_RELEASE"/dd-library-php-"$DDTRACE_EXT_RELEASE"-x86_64-linux-gnu.tar.gz"
 fi
 
-APT_DIR="$BUILD_DIR/.apt"
-APT_CACHE_DIR="$CACHE_DIR/apt/cache"
-PACKAGE_NAME="dd-php-tracer"
-PACKAGE_FILE=$APT_CACHE_DIR/archives/$PACKAGE_NAME.deb
+if [[ "$DDTRACE_EXT_PKG_URL" != *tar.gz ]]
+then
+    echo "Deprecated package URL. Please note that it is encourage to use the 'dd-library-php-*-x86_64-linux-gnu.tar.gz' distribution" | indent
+    exit 1
+fi
 
-mkdir -p $APT_CACHE_DIR/archives/partial
-mkdir -p $BUILD_DIR/.apt
+mkdir -p $CACHE_DIR
+
+PACKAGE_NAME="dd-library-php-"$DDTRACE_EXT_RELEASE
+PACKAGE_FILE=$CACHE_DIR/$PACKAGE_NAME.tar.gz
 
 topic "Downloading package from $DDTRACE_EXT_PKG_URL"
-curl --silent --show-error --fail --location --output $PACKAGE_FILE $DDTRACE_EXT_PKG_URL 2>&1 | indent
+if [[ -f ${PACKAGE_FILE} ]];
+then
+    echo "Found cached file at "$PACKAGE_FILE | indent
+else
+    curl --silent --show-error --fail --location --output $PACKAGE_FILE $DDTRACE_EXT_PKG_URL 2>&1 | indent
+fi
 
-topic "Installing ddtrace PHP extension"
-dpkg -x $PACKAGE_FILE $BUILD_DIR/.apt/
+mkdir -p $BUILD_DIR/.apt/opt
 
-topic "Enabling ddtrace PHP extension"
+topic "Installing Datadog PHP extensions"
+tar -zxvf $PACKAGE_FILE --directory=$BUILD_DIR/.apt/opt 2>&1 | indent
+
+topic "Enabling Datadog PHP extensions"
 
 if [[ -n ${DDTRACE_EXT_PHP_API:-} ]]; then
     echo "Using version '$DDTRACE_EXT_PHP_API' (from "'$DDTRACE_EXT_PHP_API env var).' | indent
@@ -76,9 +86,13 @@ else
     echo "Using version '$DDTRACE_EXT_PHP_API' (default value)." | indent
 fi
 
-touch /app/.heroku/php/etc/php/conf.d/datadog-php-custom.ini
-echo "[PHP]" >> /app/.heroku/php/etc/php/conf.d/datadog-php-custom.ini
-echo "extension=/app/.apt/opt/datadog-php/extensions/ddtrace-$DDTRACE_EXT_PHP_API.so" >> /app/.heroku/php/etc/php/conf.d/datadog-php-custom.ini
-echo "ddtrace.request_init_hook=/app/.apt/opt/datadog-php/dd-trace-sources/bridge/dd_wrap_autoloader.php" >> /app/.heroku/php/etc/php/conf.d/datadog-php-custom.ini
+INI_FILE=/app/.heroku/php/etc/php/conf.d/datadog-php-custom.ini
+INI_FILE=datadog-php-custom.ini
+
+touch $INI_FILE
+echo "[PHP]" >> $INI_FILE
+echo "extension=/app/.apt/opt/dd-library-php/trace/ext/$DDTRACE_EXT_PHP_API/ddtrace.so" >> $INI_FILE
+echo "ddtrace.request_init_hook=/app/.apt/opt/dd-library-php/trace/bridge/dd_wrap_autoloader.php" >> $INI_FILE
+echo "extension=/app/.apt/opt/dd-library-php/profiling/ext/$DDTRACE_EXT_PHP_API/datadog-profiling.so" >> $INI_FILE
 
 echo "Done" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -55,7 +55,7 @@ fi
 
 if [[ "$DDTRACE_EXT_PKG_URL" != *tar.gz ]]
 then
-    echo "Deprecated package URL. Please note that it is encourage to use the 'dd-library-php-*-x86_64-linux-gnu.tar.gz' distribution" | indent
+    echo "The package URL is out of date. Please note to use the 'dd-library-php-*-x86_64-linux-gnu.tar.gz' files from the releases at https://github.com/DataDog/dd-trace-php/releases" | indent
     exit 1
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -93,6 +93,11 @@ touch $INI_FILE
 echo "[PHP]" >> $INI_FILE
 echo "extension=/app/.apt/opt/dd-library-php/trace/ext/$DDTRACE_EXT_PHP_API/ddtrace.so" >> $INI_FILE
 echo "ddtrace.request_init_hook=/app/.apt/opt/dd-library-php/trace/bridge/dd_wrap_autoloader.php" >> $INI_FILE
-echo "extension=/app/.apt/opt/dd-library-php/profiling/ext/$DDTRACE_EXT_PHP_API/datadog-profiling.so" >> $INI_FILE
+
+if [[ -n ${DD_PROFILING_ENABLED:-} ]];
+then
+    echo "Enabling the profiler" | indent
+    echo "extension=/app/.apt/opt/dd-library-php/profiling/ext/$DDTRACE_EXT_PHP_API/datadog-profiling.so" >> $INI_FILE
+fi
 
 echo "Done" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ export_env_dir() {
     fi
 }
 
-export_env_dir "$ENV_DIR" '^DDTRACE_EXT_'
+export_env_dir "$ENV_DIR" '^DDTRACE_EXT|DD_'
 
 topic "Preparing to install Datadog PHP extensions"
 

--- a/bin/compile
+++ b/bin/compile
@@ -68,6 +68,10 @@ topic "Downloading package from $DDTRACE_EXT_PKG_URL"
 if [[ -f ${PACKAGE_FILE} ]];
 then
     echo "Found cached file at "$PACKAGE_FILE | indent
+    if ! gzip -t ${PACKAGE_FILE} 2>&1 | indent ; then
+        echo "cache is invalid, downloading ..." | indent
+        curl --silent --show-error --fail --location --output $PACKAGE_FILE $DDTRACE_EXT_PKG_URL 2>&1 | indent
+    fi
 else
     curl --silent --show-error --fail --location --output $PACKAGE_FILE $DDTRACE_EXT_PKG_URL 2>&1 | indent
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-echo "ddtrace PHP extension"
+echo "Datadog PHP extensions"
 exit 0


### PR DESCRIPTION
Hey there 👋 

first of all, thanks for maintaining this buildpack 🙇, I just found it due to a customer question. 
This PR proposes some changes which I hope you'll find usefull:
- switch to the `dd-library-php` distribution and away from the `.deb` file. This also brings the profiler and appsec in case someone needs it
- allow for installation of the profiler by setting `DD_PROFILING_ENABLED` environment variable to a non empty value
- bump default version to latest `0.87.2`
- utilise the Heroku build cache to not download the same file over and over again

I am very curious what you think about these changes and I like to express it again: thanks 🙇 

FYI: we encourage folks to use the `datadog-setup.php` to install, but due the PHP INI scandir pointing to some temporary directory during buildpack execution, the installer would use the wrong paths to add it's INI files. I'll have a look if we can easily detect and support Heroku in our installer and would like to make another PR when we have this.