### PR TITLE
Install latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ needed to run the installer.
 
 This buildpack accepts several config vars. All of them are optional:
 
-- `DD_RELEASE` - The release name of [dd-trace-php](https://github.com/DataDog/dd-trace-php/releases/) to download. Defaults to `0.87.2`.
+- `DD_RELEASE` - The release version of [dd-trace-php](https://github.com/DataDog/dd-trace-php/releases/) to download. Uses latest release if omited.
 - `DD_INSTALLER_URL` - The URL to the `datadog-setup.php` to be used (to be found on the [dd-trace-php release page](https://github.com/DataDog/dd-trace-php/releases/)).
 - `DD_PROFILING_ENABLED` - Set to a non empty value, this will install and enable the profiling extension.
 - `DD_APPSEC_ENABLED` - Set to a non empty value, this will install and enable the appsec extension.
+
+**Note:** In case `DD_RELEASE` is omited, this will always install the latest version.

--- a/bin/compile
+++ b/bin/compile
@@ -64,11 +64,11 @@ if [[ -n ${DD_INSTALLER_URL:-} ]]; then
 else
     if [[ -n ${DD_RELEASE:-} ]]; then
         echo "Using dd-trace-php release '$DD_RELEASE' (from "'$DD_RELEASE env var).' | indent
+        export DD_INSTALLER_URL="https://github.com/DataDog/dd-trace-php/releases/download/"$DD_RELEASE"/datadog-setup.php"
     else
-        export DD_RELEASE="0.87.2"
-        echo "Using dd-trace-php release '$DD_RELEASE' (default value)." | indent
+        echo "Using 'latest' dd-trace-php release (default)." | indent
+        export DD_INSTALLER_URL="https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php"
     fi
-    export DD_INSTALLER_URL="https://github.com/DataDog/dd-trace-php/releases/download/"$DD_RELEASE"/datadog-setup.php"
 fi
 
 if [[ "$DD_INSTALLER_URL" != *datadog-setup.php ]]


### PR DESCRIPTION
Hey there again 👋 

I wanted to upgrade the default `DD_RELEASE` version when I thought it might be beneficial to default to the latest version, so we spare upgrading this variable with every release. I also added a note in the `README.md` stating this behaviour, so that people know they could pin to a specific version using the `DD_RELEASE` variable just in case.
What do you think?