### PR TITLE
Fix absolute paths after install

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -99,6 +99,11 @@ mkdir -p $BUILD_DIR/opt
 
 env -u PHP_INI_SCAN_DIR php datadog-setup.php --php-bin=all --install-dir=$BUILD_DIR/opt $OPTS 2>&1 | indent
 
+# This is needed as some INI-settings are absolute paths that are pointing to
+# $BUILD_DIR after installation, but during runtime those files will be mounted
+# in `/app`.
+sed -i "s|$BUILD_DIR|/app|" /app/.heroku/php/etc/php/conf.d/98-ddtrace.ini
+
 topic "Validating installation"
 
 env -u PHP_INI_SCAN_DIR php -v 2>&1 | indent


### PR DESCRIPTION
Hey there 👋 

the installer adds some absolute paths to the `98-ddtrace.ini` file that point to the installation path in `/tmp/build_FOOBAR`, but during runtime those files are mounted in the `/app` directory and the temporary build directory does not exist anymore.
In your case it should be the `datadog.trace.request_init_hook` pointing most likely to `/tmp/build_66de75e8/opt/dd-library/0.90.0/dd-trace-sources/bridge/dd_wrap_autoloader.php` which should be `/app/opt/dd-library/0.90.0/dd-trace-sources/bridge/dd_wrap_autoloader.php` instead.

This PR fixes this also for an AppSec file.

You may try using this buildpack via:
```bash
heroku buildpacks:add https://github.com/realFlowControl/heroku-buildpack-php-ddtrace.git#hotfix
```
After this the `request_init_hook` should be correct and you should start seeing `mysql` traces again.
Sorry for the problems this might have caused 🙇 